### PR TITLE
Allow jquery and cash object to be passed to init

### DIFF
--- a/types/materialize-css/autocomplete.d.ts
+++ b/types/materialize-css/autocomplete.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init autocompletes
          */
-        static init(els: NodeListOf<Element>, options?: Partial<AutocompleteOptions>): Autocomplete[];
+        static init(els: MElements, options?: Partial<AutocompleteOptions>): Autocomplete[];
 
         /**
          * Select a specific autocomplete options.

--- a/types/materialize-css/carousel.d.ts
+++ b/types/materialize-css/carousel.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init carousels
          */
-        static init(els: NodeListOf<Element>, options?: Partial<CarouselOptions>): Carousel[];
+        static init(els: MElements, options?: Partial<CarouselOptions>): Carousel[];
 
         /**
          * If the carousel is being clicked or tapped

--- a/types/materialize-css/character-counter.d.ts
+++ b/types/materialize-css/character-counter.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init CharacterCounters
          */
-        static init(els: NodeListOf<Element>, options?: Partial<undefined>): CharacterCounter[];
+        static init(els: MElements, options?: Partial<undefined>): CharacterCounter[];
     }
 }
 

--- a/types/materialize-css/chips.d.ts
+++ b/types/materialize-css/chips.d.ts
@@ -16,7 +16,7 @@ declare namespace M {
         /**
          * Init Chipses
          */
-        static init(els: NodeListOf<Element>, options?: Partial<ChipsOptions>): Chips[];
+        static init(els: MElements, options?: Partial<ChipsOptions>): Chips[];
 
         /**
          * Array of the current chips data

--- a/types/materialize-css/collapsible.d.ts
+++ b/types/materialize-css/collapsible.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Collapsibles
          */
-        static init(els: NodeListOf<Element>, options?: Partial<CollapsibleOptions>): Collapsible[];
+        static init(els: MElements, options?: Partial<CollapsibleOptions>): Collapsible[];
 
         /**
          * Open collapsible section

--- a/types/materialize-css/common.d.ts
+++ b/types/materialize-css/common.d.ts
@@ -1,3 +1,8 @@
+/// <reference types="jquery"/>
+/// <reference types="cash"/>
+
+type MElements = NodeListOf<Element> | JQuery | Cash;
+
 declare namespace M {
     abstract class Component<TOptions> extends ComponentBase<TOptions> {
         /**

--- a/types/materialize-css/datepicker.d.ts
+++ b/types/materialize-css/datepicker.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Datepickers
          */
-        static init(els: NodeListOf<Element>, options?: Partial<DatepickerOptions>): Datepicker[];
+        static init(els: MElements, options?: Partial<DatepickerOptions>): Datepicker[];
 
         /**
          * If the picker is open.

--- a/types/materialize-css/dropdown.d.ts
+++ b/types/materialize-css/dropdown.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Dropdowns
          */
-        static init(els: NodeListOf<Element>, options?: Partial<DropdownOptions>): Dropdown[];
+        static init(els: MElements, options?: Partial<DropdownOptions>): Dropdown[];
 
         /**
          * ID of the dropdown element

--- a/types/materialize-css/fab.d.ts
+++ b/types/materialize-css/fab.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init FloatingActionButtons
          */
-        static init(els: NodeListOf<Element>, options?: Partial<FloatingActionButtonOptions>): FloatingActionButton[];
+        static init(els: MElements, options?: Partial<FloatingActionButtonOptions>): FloatingActionButton[];
 
         /**
          * Open FAB

--- a/types/materialize-css/formselect.d.ts
+++ b/types/materialize-css/formselect.d.ts
@@ -16,7 +16,7 @@ declare namespace M {
         /**
          * Init FormSelects
          */
-        static init(els: NodeListOf<Element>, options?: Partial<FormSelectOptions>): FormSelect[];
+        static init(els: MElements, options?: Partial<FormSelectOptions>): FormSelect[];
 
         /**
          * If this is a multiple select

--- a/types/materialize-css/materialbox.d.ts
+++ b/types/materialize-css/materialbox.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Materialboxes
          */
-        static init(els: NodeListOf<Element>, options?: Partial<MaterialboxOptions>): Materialbox[];
+        static init(els: MElements, options?: Partial<MaterialboxOptions>): Materialbox[];
 
         /**
          * Open materialbox

--- a/types/materialize-css/modal.d.ts
+++ b/types/materialize-css/modal.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Modals
          */
-        static init(els: NodeListOf<Element>, options?: Partial<ModalOptions>): Modal[];
+        static init(els: MElements, options?: Partial<ModalOptions>): Modal[];
 
         /**
          * Open modal

--- a/types/materialize-css/parallax.d.ts
+++ b/types/materialize-css/parallax.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Parallaxs
          */
-        static init(els: NodeListOf<Element>, options?: Partial<ParallaxOptions>): Parallax[];
+        static init(els: MElements, options?: Partial<ParallaxOptions>): Parallax[];
     }
 
     interface ParallaxOptions {

--- a/types/materialize-css/pushpin.d.ts
+++ b/types/materialize-css/pushpin.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Pushpins
          */
-        static init(els: NodeListOf<Element>, options?: Partial<PushpinOptions>): Pushpin[];
+        static init(els: MElements, options?: Partial<PushpinOptions>): Pushpin[];
 
         /**
          * Original offsetTop of element

--- a/types/materialize-css/range.d.ts
+++ b/types/materialize-css/range.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Ranges
          */
-        static init(els: NodeListOf<Element>, options?: Partial<undefined>): Range[];
+        static init(els: MElements, options?: Partial<undefined>): Range[];
     }
 }
 

--- a/types/materialize-css/scrollspy.d.ts
+++ b/types/materialize-css/scrollspy.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init ScrollSpies
          */
-        static init(els: NodeListOf<Element>, options?: Partial<ScrollSpyOptions>): ScrollSpy[];
+        static init(els: MElements, options?: Partial<ScrollSpyOptions>): ScrollSpy[];
     }
 
     interface ScrollSpyOptions {

--- a/types/materialize-css/sidenav.d.ts
+++ b/types/materialize-css/sidenav.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Sidenavs
          */
-        static init(els: NodeListOf<Element>, options?: Partial<SidenavOptions>): Sidenav[];
+        static init(els: MElements, options?: Partial<SidenavOptions>): Sidenav[];
 
         /**
          * Opens Sidenav

--- a/types/materialize-css/slider.d.ts
+++ b/types/materialize-css/slider.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Sliders
          */
-        static init(els: NodeListOf<Element>, options?: Partial<SliderOptions>): Slider[];
+        static init(els: MElements, options?: Partial<SliderOptions>): Slider[];
 
         /**
          * ID of the dropdown element

--- a/types/materialize-css/tabs.d.ts
+++ b/types/materialize-css/tabs.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Tabses
          */
-        static init(els: NodeListOf<Element>, options?: Partial<TabsOptions>): Tabs[];
+        static init(els: MElements, options?: Partial<TabsOptions>): Tabs[];
 
         /**
          * Show tab content that corresponds to the tab with the id

--- a/types/materialize-css/taptarget.d.ts
+++ b/types/materialize-css/taptarget.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init TapTargets
          */
-        static init(els: NodeListOf<Element>, options?: Partial<TapTargetOptions>): TapTarget[];
+        static init(els: MElements, options?: Partial<TapTargetOptions>): TapTarget[];
 
         /**
          * Open Tap Target

--- a/types/materialize-css/test/common.test.ts
+++ b/types/materialize-css/test/common.test.ts
@@ -1,0 +1,14 @@
+/// <reference types="cash"/>
+import * as M from "materialize-css";
+import * as jQuery from "jquery";
+
+// Test Component Initialization
+
+// $ExpectType Autocomplete
+M.Autocomplete.init(document.querySelector('.whatever')!);
+// $ExpectType Autocomplete[]
+M.Autocomplete.init(document.querySelectorAll('.whatever'));
+// $ExpectType Autocomplete[]
+M.Autocomplete.init(jQuery('.whatever'));
+// $ExpectType Autocomplete[]
+M.Autocomplete.init(cash('.whatever'));

--- a/types/materialize-css/timepicker.d.ts
+++ b/types/materialize-css/timepicker.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Timepickers
          */
-        static init(els: NodeListOf<Element>, options?: Partial<TimepickerOptions>): Timepicker[];
+        static init(els: MElements, options?: Partial<TimepickerOptions>): Timepicker[];
 
         /**
          * If the picker is open.

--- a/types/materialize-css/tooltip.d.ts
+++ b/types/materialize-css/tooltip.d.ts
@@ -15,7 +15,7 @@ declare namespace M {
         /**
          * Init Tooltips
          */
-        static init(els: NodeListOf<Element>, options?: Partial<TooltipOptions>): Tooltip[];
+        static init(els: MElements, options?: Partial<TooltipOptions>): Tooltip[];
 
         /**
          * Show tooltip.

--- a/types/materialize-css/tsconfig.json
+++ b/types/materialize-css/tsconfig.json
@@ -24,6 +24,7 @@
         "test/character-counter.test.ts",
         "test/chips.test.ts",
         "test/collapsible.test.ts",
+        "test/common.test.ts",
         "test/datepicker.test.ts",
         "test/dropdown.test.ts",
         "test/fab.test.ts",


### PR DESCRIPTION
`Init` method not only accept  `NodeListOf<Element>`, but also jQuery and cash object.